### PR TITLE
Update main.ts to require space after prompt marker.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,7 +11,7 @@ export default class CodePlugin extends Plugin {
 
       const pre = el.createEl("pre", { cls: "language-console" });
       for (const line of lines) {
-        const m = line.match(/^\s*([>#%\$])\s*(.+)$/);
+        const m = line.match(/^\s*([>#%\$])\s+(.+)$/);
         if (m != null) {
           const div = pre.createEl("div");
           div.createEl(


### PR DESCRIPTION
Prevents the output of commands which start with a prompt marker from being rendered as a command. 

eg:
```console
$ openssl passwd YourPassword
$1$LA1Btwdz$lw4Ktzx0X2haxFsJn.t7D0
```